### PR TITLE
Нецелое время задержки (консольный параметр delay)

### DIFF
--- a/rosreestr2coord/console.py
+++ b/rosreestr2coord/console.py
@@ -5,7 +5,7 @@ import signal
 import sys
 
 from rosreestr2coord.batch import batch_parser
-from rosreestr2coord.parser import Area, TYPESf
+from rosreestr2coord.parser import Area, TYPES
 from rosreestr2coord.version import VERSION
 
 

--- a/rosreestr2coord/console.py
+++ b/rosreestr2coord/console.py
@@ -5,7 +5,7 @@ import signal
 import sys
 
 from rosreestr2coord.batch import batch_parser
-from rosreestr2coord.parser import Area, TYPES
+from rosreestr2coord.parser import Area, TYPESf
 from rosreestr2coord.version import VERSION
 
 
@@ -40,9 +40,9 @@ def getopts():
     parser.add_argument('-d', '--display', action='store_const', const=True,
                         required=False,
                         help='display plot (only for --code mode)')
-    parser.add_argument('-D', '--delay', action='store', type=int,
+    parser.add_argument('-D', '--delay', action='store', type=float,
                         required=False, default=1,
-                        help='delay between request (only for --list mode)')
+                        help='delay between requests (only for --list mode)')
     parser.add_argument('-r', '--refresh', action='store_const', const=True,
                         required=False,
                         help='do not use cache')


### PR DESCRIPTION
См. #41 

* Тип консольного параметра `--delay` изменён с `int` на `float`.
* Исправлена грамматическая ошибка в описании этого параметра.