### PR TITLE
Добавлено декодирование респонса в utf-8 

### DIFF
--- a/rosreestr2coord/merge_tiles.py
+++ b/rosreestr2coord/merge_tiles.py
@@ -384,7 +384,7 @@ class PkkAreaMerger(TileMerger, object):
                 try:
                     if not data:
                         response = self.make_request(meta_url)
-                        data = json.loads(response)
+                        data = json.loads(response.decode('utf-8'))
                         if data.get("imageData") and data.get("extent"):
                             with open(cache_path, 'w') as outfile:
                                 json.dump(data, outfile)

--- a/rosreestr2coord/parser.py
+++ b/rosreestr2coord/parser.py
@@ -215,7 +215,7 @@ class Area:
                 search_url = self.feature_info_url + self.clear_code(self.code)
                 self.log('Start downloading area info: %s' % search_url)
                 resp = self.make_request(search_url)
-                data = json.loads(resp)
+                data = json.loads(resp.decode('utf-8'))
                 self.log('Area info downloaded.')
                 with open(feature_info_path, 'w') as outfile:
                     json.dump(data, outfile)


### PR DESCRIPTION
Добавлено декодирование респонса в utf-8 перед конвертацией в json объект, иначе не работает на python версии 3.5.3 и в логах пишет: TypeError: the JSON object must be str, not 'bytes'.