### PR TITLE
Добавил переменную `__all__` 

### DIFF
--- a/rosreestr2coord/__init__.py
+++ b/rosreestr2coord/__init__.py
@@ -1,1 +1,5 @@
 from rosreestr2coord.parser import Area
+
+__all__ = (
+    "Area",
+)


### PR DESCRIPTION
Пояснение:
Без него нормально не работает импорты в IDE (vscode например) - просто не видит "Area" как класс. 

Без `__all__ ` не будет работать такой импорт:
```python
from rosreestr2coord import *
```

Плюс - линтер ругается