### PR TITLE
Добавлена возможность указывать конкретный прокси в командной строке

### DIFF
--- a/rosreestr2coord/__main__.py
+++ b/rosreestr2coord/__main__.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # coding: utf-8
-from rosreestr2coord.console import console
 
+import sys,os
+sys.path.append(os.getcwd())
+
+from rosreestr2coord.console import console
 
 if __name__ == "__main__":
     console()

--- a/rosreestr2coord/console.py
+++ b/rosreestr2coord/console.py
@@ -126,6 +126,14 @@ def getopts():
         required=False,
         help="show current version",
     )
+    parser.add_argument(
+        "-u",
+        "--proxy_url",
+        action="store",
+        type=str,
+        required=False,
+        help="set proxy url",
+    )
     opts = parser.parse_args()
     return opts
 
@@ -142,6 +150,7 @@ def run_console(opt):
         "center_only": opt.center_only if opt.center_only else False,
         "use_cache": False if opt.refresh else True,
         "coord_out": "EPSG:4326",
+        "proxy_url": opt.proxy_url
     }
 
     if opt.list:

--- a/rosreestr2coord/parser.py
+++ b/rosreestr2coord/parser.py
@@ -100,6 +100,7 @@ class Area:
         proxy_handler=None,
         timeout=5,
         logger=logger,
+        proxy_url=None
     ):
         self.with_log = with_log
         self.area_type = area_type
@@ -107,6 +108,8 @@ class Area:
         self.center_only = center_only
         self.epsilon = epsilon
         self.code = code
+
+        self.proxy_url = proxy_url
 
         self.file_name = code_to_filename(self.code[:])
         self.with_proxy = with_proxy
@@ -226,6 +229,7 @@ class Area:
             proxy_handler=proxy_handler,
             logger=self.logger,
             timeout=self.timeout,
+            proxy_url=self.proxy_url
         )
         return response
 


### PR DESCRIPTION
Многие пользуются собственными платными прокси
Добавил возможность указать сразу нужный прокси сервер через командную строку, чтобы не использовать полу-живые бесплатные
Пример использования:

rosreestr2coord -c=77:08:0013004:15 --proxy_url=http://user:password@46.161.44.97:9853