### PR TITLE
fix: restore Area export in __init__.py

### DIFF
--- a/rosreestr2coord/__init__.py
+++ b/rosreestr2coord/__init__.py
@@ -1,1 +1,3 @@
+from rosreestr2coord.parser import Area
 
+__all__ = ("Area",)


### PR DESCRIPTION
## Summary

- Restores `Area` class export in `rosreestr2coord/__init__.py`
- The export was accidentally removed in commit 4153b54 ("feat: add CI workflow and enhance testing setup")
- This broke the documented import: `from rosreestr2coord import Area`

Fixes #106

## Changes

`rosreestr2coord/__init__.py`:
```python
from rosreestr2coord.parser import Area

__all__ = ("Area",)
```

This restores the state from before the regression (see commit fc720ff).

## Test plan

- [ ] `from rosreestr2coord import Area` works without ImportError
- [ ] Existing tests pass (`pytest -m "not integration"`)