### PR TITLE
fix: replace global basicConfig with NullHandler

### DIFF
--- a/rosreestr2coord/logger.py
+++ b/rosreestr2coord/logger.py
@@ -1,4 +1,4 @@
 import logging
 
-logging.basicConfig(filename="debug.log", level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
## Summary

- Replaces `logging.basicConfig(filename="debug.log", level=logging.DEBUG)` with `logging.NullHandler()`
- The `basicConfig()` call in `logger.py` overrides the root logger for any application that imports `rosreestr2coord`, silently redirecting all logs to a `debug.log` file
- `NullHandler` is the [recommended approach](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) for library logging in Python

Fixes #93

## Before
```python
import rosreestr2coord
# All application logs now go to debug.log instead of console
```

## After
```python
import rosreestr2coord
# Application logging is unaffected
# Users can configure rosreestr2coord logging explicitly if needed:
# logging.getLogger("rosreestr2coord").setLevel(logging.DEBUG)
```

## Test plan

- [ ] Importing `rosreestr2coord` no longer creates `debug.log`
- [ ] Application logging remains unaffected after import
- [ ] Library internal logging still works when explicitly configured