### PR TITLE
fix: update batch/export to use current Area API

### DIFF
--- a/rosreestr2coord/batch.py
+++ b/rosreestr2coord/batch.py
@@ -27,7 +27,7 @@ def batch_parser(
             sleep(need_sleep)
             area = Area(code, with_log=with_log, **kwargs)
             need_sleep = delay
-            if len(area.get_coord()):
+            if area.feature:
                 print(" - ok", end="")
                 success += 1
             else:

--- a/rosreestr2coord/console.py
+++ b/rosreestr2coord/console.py
@@ -57,7 +57,7 @@ def get_by_code(code, output, display, **kwargs):
 
 
 def process_area(area, output_path, display):
-    geojson = area.to_geojson_poly()
+    geojson = area.to_geojson()
 
     file_name = code_to_filename(area.file_name)
 

--- a/rosreestr2coord/export.py
+++ b/rosreestr2coord/export.py
@@ -18,12 +18,11 @@ def make_output(output, file_name, file_format, out_path=""):
 
 def _write_csv_row(f, area, header=False):
     try:
-        xy = copy.deepcopy(list(area.get_coord()))
-        for geom in xy:
-            for poly in geom:
-                for c in range(len(poly)):
-                    poly[c] = poly[c][::-1]
-        attrs = getattr(area, "attrs", {})
+        if not area.feature:
+            return
+        geometry = area.feature.get("geometry", {})
+        xy = copy.deepcopy(geometry.get("coordinates", []))
+        attrs = area.feature.get("properties", {})
         address = attrs.get("address", "")
         cols = [
             {"name": "code", "value": getattr(area, "code")},
@@ -64,7 +63,7 @@ def batch_json_output(output, areas, file_name, with_attrs=True, crs_name="EPSG:
     }
     path = make_output(output, file_name, "geojson")
     for a in areas:
-        feature = a.to_geojson_poly(with_attrs, dumps=False)
+        feature = a.to_geojson(dumps=False)
         if feature:
             features.append(feature)
 
@@ -74,8 +73,8 @@ def batch_json_output(output, areas, file_name, with_attrs=True, crs_name="EPSG:
     return path
 
 
-def area_json_output(output, area, with_attrs=True):
-    geojson = area.to_geojson_poly(with_attrs)
+def area_json_output(output, area):
+    geojson = area.to_geojson()
     if geojson:
         f = open(make_output(output, area.file_name, "geojson"), "w")
         f.write(geojson)


### PR DESCRIPTION
## Summary

Fixes batch processing and export functions that broke after the Area API was refactored in v5.0.0.

**Changes:**
- `batch.py`: replace removed `area.get_coord()` with `area.feature` check
- `export.py`: replace `to_geojson_poly(with_attrs, dumps=False)` with `to_geojson(dumps=False)` — the old call caused `TypeError: got multiple values for argument 'dumps'`
- `export.py`: update `_write_csv_row` to extract coordinates and attributes from `area.feature` instead of removed `get_coord()` and `attrs`
- `console.py`: replace deprecated `to_geojson_poly()` with `to_geojson()`

Fixes #100

## Root cause

In v5.0.0 the `Area` class was refactored:
- `get_coord()` was removed (geometry is now in `area.feature`)
- `to_geojson_poly()` signature changed to `(self, dumps=True)` only
- `area.attrs` was removed (properties are now in `area.feature["properties"]`)

But `batch.py`, `export.py`, and `console.py` were not updated to match.

## Test plan

- [ ] `rosreestr2coord -l list.txt` processes batch files without errors
- [ ] GeoJSON output is generated correctly
- [ ] CSV output includes coordinates and properties
- [ ] Single code processing still works: `rosreestr2coord -c "77:01:0001:123"`