### PR TITLE
feat: add cadastral code format validation

### DIFF
--- a/rosreestr2coord/parser.py
+++ b/rosreestr2coord/parser.py
@@ -9,7 +9,7 @@ from .export import coords2kml
 from .logger import logger
 from .request.proxy_handling import ProxyHandling
 from .request.request import make_request
-from .utils import clear_code, code_to_filename, transform_to_wgs
+from .utils import clear_code, code_to_filename, transform_to_wgs, validate_code
 
 TYPES = {
     "Объекты недвижимости": 1,
@@ -53,6 +53,9 @@ class Area:
         self.proxy_handler: Optional[ProxyHandling] = proxy_handler
         self.proxy_url: Optional[str] = proxy_url
         self.logger: logging.Logger = logger or logging.getLogger(__name__)
+
+        if self.code:
+            validate_code(self.code)
 
         self.file_name: str = code_to_filename(self.code)
         self.feature: Optional[dict] = None

--- a/rosreestr2coord/utils.py
+++ b/rosreestr2coord/utils.py
@@ -34,6 +34,30 @@ def transform_to_wgs(geojson: dict) -> dict:
     return result
 
 
+
+def validate_code(code: str) -> None:
+    """
+    Validate cadastral number format.
+
+    Accepted formats:
+        - Full:     XX:XX:XXXXXXX:XXXX  (parcel / building)
+        - Quarter:  XX:XX:XXXXXXX
+        - District: XX:XX
+        - Region:   XX
+
+    Raises ValueError if the format is invalid.
+    """
+    if not code or not isinstance(code, str):
+        raise ValueError(f"Cadastral code must be a non-empty string, got: {code!r}")
+
+    code = code.strip()
+    pattern = r"^\d{1,2}(:\d{1,2}(:\d{5,7}(:\d+)?)?)?$"
+    if not re.match(pattern, code):
+        raise ValueError(
+            f"Invalid cadastral code format: '{code}'. "
+            f"Expected format: XX:XX:XXXXXXX:XXXX (e.g. 50:20:0010203:456)"
+        )
+
 def clear_code(code: str) -> str:
     """
     Remove first nulls from code xxxx:00xx >> xxxx:xx

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,63 @@
+import pytest
+from rosreestr2coord.utils import validate_code
+
+
+class TestValidateCode:
+    """Tests for cadastral number validation."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "50:20:0010203:456",    # full parcel number
+            "38:06:144003:4723",    # full with leading zeros
+            "77:01:0001234:99",     # Moscow
+            "02:02:0000000:1",      # single-digit parcel
+            "50:20:0010203",        # quarter
+            "50:20",                # district
+            "50",                   # region
+            "1:1:10000:1",          # minimal digits
+            "99:99:9999999:99999",  # max region/district, long parcel
+        ],
+    )
+    def test_valid_codes(self, code):
+        validate_code(code)  # should not raise
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "",                         # empty
+            "abc",                      # letters
+            "50-20-0010203-456",        # wrong delimiter
+            "50:20:0010203:456:789",    # too many parts
+            "123:20:0010203:456",       # region > 2 digits
+            "50:123:0010203:456",       # district > 2 digits
+            "50:20:1234:456",           # quarter too short (< 5 digits)
+            "50:20:12345678:456",       # quarter too long (> 7 digits)
+            "50:20:00102AB:456",        # non-digits in quarter
+            ":20:0010203:456",          # empty region
+            "50:20:0010203:",           # empty parcel
+        ],
+    )
+    def test_invalid_codes(self, code):
+        with pytest.raises(ValueError, match="Invalid cadastral code format"):
+            validate_code(code)
+
+    @pytest.mark.unit
+    def test_none_input(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            validate_code(None)
+
+    @pytest.mark.unit
+    def test_whitespace_stripped(self):
+        validate_code("  50:20:0010203:456  ")  # should not raise
+
+
+@pytest.mark.unit
+def test_area_rejects_invalid_code():
+    """Area.__init__ should raise ValueError for invalid cadastral codes."""
+    from rosreestr2coord.parser import Area
+
+    with pytest.raises(ValueError, match="Invalid cadastral code"):
+        Area("not-a-valid-code", area_type=1, with_log=False)


### PR DESCRIPTION
## Summary

Adds input validation for cadastral codes passed to `Area()`.

Currently, any string is accepted as a cadastral code — invalid inputs silently produce empty results or cryptic API errors. This PR adds a `validate_code()` function that checks the format before making API requests.

### Accepted formats
- Full parcel/building: `XX:XX:XXXXXXX:XXXX` (e.g. `50:20:0010203:456`)
- Quarter: `XX:XX:XXXXXXX`
- District: `XX:XX`
- Region: `XX`

### Changes
- **`rosreestr2coord/utils.py`** — new `validate_code()` function with regex validation
- **`rosreestr2coord/parser.py`** — call `validate_code()` in `Area.__init__()` when code is provided
- **`tests/test_validation.py`** — parametrized tests for valid/invalid codes + integration test with `Area`

### Related
Closes #64

### Example
```python
from rosreestr2coord import Area

# Before: silently fails or returns empty result
Area("not-a-code")

# After: raises ValueError with clear message
# ValueError: Invalid cadastral code format: 'not-a-code'.
# Expected format: XX:XX:XXXXXXX:XXXX (e.g. 50:20:0010203:456)
```